### PR TITLE
Add minimal Flutter app setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+build/
+
+# Generated files
+pubspec.lock
+
+# Misc
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # flutter-ui-study
+
+This project contains a minimal Flutter application. To run it locally:
+
+1. Install [Flutter](https://flutter.dev/docs/get-started/install).
+2. Fetch dependencies:
+   ```bash
+   flutter pub get
+   ```
+3. Run the app:
+   ```bash
+   flutter run
+   ```
+4. Run tests:
+   ```bash
+   flutter test
+   ```
+
+The main entry point is located at `lib/main.dart` and displays a simple "Hello, Flutter!" message.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'Flutter UI Study',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Flutter UI Study'),
+        ),
+        body: Center(
+          child: Text('Hello, Flutter!'),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: flutter_ui_study
+description: A new Flutter project.
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_ui_study/main.dart';
+
+void main() {
+  testWidgets('App starts', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.text('Hello, Flutter!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Scaffold minimal Flutter application with a simple `Hello, Flutter!` screen
- Add basic widget test and configuration files
- Document how to run and test the app locally

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fe30220c8324a410f2db96bac061